### PR TITLE
스프링 컨테이너 생성 및 빈 등록, 빈 조회

### DIFF
--- a/src/main/java/hello/core/AppConfig.java
+++ b/src/main/java/hello/core/AppConfig.java
@@ -7,31 +7,41 @@ import hello.core.member.MemberServiceImpl;
 import hello.core.member.MemoryMemberRepository;
 import hello.core.order.OrderService;
 import hello.core.order.OrderServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-// 구현 클래스가 직접 객체(구현체)를 선택하는 것은 배우가 배역을 선택하는 것과 같다.
-// 즉, 로미오 역할을 맡은 배우가 줄리엣 역할을 맡을 배우를 선택하는 것.
-// 배우는 너무 많은 책임을 지게 되고, 별도의 기획자가 필요하다. 애플리케이션도 마찬가지. (책임 분리)
-// 애플리케이션의 전체 동작 방식을 구성하기 위해 구현 객체를 생성하고 연결하는 책임을 가지는 별도의 설정 클래스
+/*
+ 구현 클래스가 직접 객체(구현체)를 선택하는 것은 배우가 배역을 선택하는 것과 같다.
+ 즉, 로미오 역할을 맡은 배우가 줄리엣 역할을 맡을 배우를 선택하는 것.
+ 배우는 너무 많은 책임을 지게 되고, 별도의 기획자가 필요하다. 애플리케이션도 마찬가지. (책임 분리)
+ 애플리케이션의 전체 동작 방식을 구성하기 위해 구현 객체를 생성하고 연결하는 책임을 가지는 별도의 설정 클래스 */
+// 스프링으로 전환: @Configuration, @Bean 을 붙여줌
+@Configuration // Application의 설정/구성 정보를 담당함
 public class AppConfig {
 
-    // 리팩토링: 역할이 더 잘 드러나도록 리팩토링
-    // new Class() 를 메소드로 추출: 어떤 '역할'이 존재하고, 역할에 어떤 구현체를 넣을 지 한 눈에 보인다.
-    // 예시: new MemberServiceImpl(new MemoryMemberRepository()); 에서
-    // Repository 는 역할에 해당하므로 메소드로 추출해준다
-    // 결과: new MemberServiceImpl(memberRepository());
-    // >> 역할을 명확하게 한 눈에 볼 수 있을 뿐만 아니라 역할에 사용되는 구현체가 바뀔 때 코드 수정도 줄어든다.
+     /*
+     리팩토링: 역할이 더 잘 드러나도록 리팩토링
+     new Class() 를 메소드로 추출: 어떤 '역할'이 존재하고, 역할에 어떤 구현체를 넣을 지 한 눈에 보인다.
+     예시: new MemberServiceImpl(new MemoryMemberRepository()); 에서
+     Repository 는 역할에 해당하므로 메소드로 추출해준다
+            결과: new MemberServiceImpl(memberRepository());
+     >> 역할을 명확하게 한 눈에 볼 수 있을 뿐만 아니라 역할에 사용되는 구현체가 바뀔 때 코드 수정도 줄어든다. */
+    @Bean // 스프링 컨테이너에 등록
     public MemberService memberService(){
         return new MemberServiceImpl(memberRepository());
     }
 
-    private static MemoryMemberRepository memberRepository() {
+    @Bean
+    public static MemoryMemberRepository memberRepository() {
         return new MemoryMemberRepository();
     }
 
+    @Bean
     public OrderService orderService(){
         return new OrderServiceImpl(memberRepository(), discountPolicy());
     }
 
+    @Bean
     public DiscountPolicy discountPolicy(){
 //        return new FixDiscountPolicy();
         return new RateDiscountPolicy();

--- a/src/main/java/hello/core/MemberApp.java
+++ b/src/main/java/hello/core/MemberApp.java
@@ -1,14 +1,28 @@
 package hello.core;
 
-import hello.core.member.*;
+import hello.core.member.Grade;
+import hello.core.member.Member;
+import hello.core.member.MemberService;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class MemberApp {
     public static void main(String[] args) {
 
-//        MemberService memberService = new MemberServiceImpl();
-        // AppConfig가 객체 생성을 관리.
+/*      MemberService memberService = new MemberServiceImpl();
+        //AppConfig가 객체 생성을 관리.
         AppConfig appConfig = new AppConfig();
-        MemberService memberService = appConfig.memberService();
+        MemberService memberService = appConfig.memberService();*/
+
+         /*ApplicationContext: 스프링 컨테이너
+         AppConfig 가 어노테이션을 기반으로 설정하고 있기 때문에 AnnotationConfigApplicationContext 객체를 생성하고, AppConfig 를 주입
+         -> 스프링이 컨테이너에 @Bean 을 넣어 관리*/
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        // ApplicationContext("메서드명", 반환타입)
+        // 메서드명: 스프링 빈은 스프링 컨테이너에 "메서드 이름"으로 저장된다. MemberService 객체를 생성하는 메서드가 memberService() 이므로 memberService 를 넣어준다.
+        MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
+
         Member member = new Member(1L, "memberA", Grade.VIP);
         memberService.join(member);
 

--- a/src/main/java/hello/core/OrderApp.java
+++ b/src/main/java/hello/core/OrderApp.java
@@ -5,15 +5,21 @@ import hello.core.member.Member;
 import hello.core.member.MemberService;
 import hello.core.order.Order;
 import hello.core.order.OrderService;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class OrderApp {
     public static void main(String[] args) {
 //        MemberService memberService = new MemberServiceImpl(null);
 //        OrderService orderService = new OrderServiceImpl(null, null);
 
-        AppConfig appConfig = new AppConfig();
-        MemberService memberService = appConfig.memberService();
-        OrderService orderService = appConfig.orderService();
+//        AppConfig appConfig = new AppConfig();
+//        MemberService memberService = appConfig.memberService();
+//        OrderService orderService = appConfig.orderService();
+
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
+        MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
+        OrderService orderService = applicationContext.getBean("orderService", OrderService.class);
 
         Long memberId = 1L;
         Member member = new Member(memberId, "memberA", Grade.VIP);

--- a/src/test/java/hello/core/beanfind/ApplicationContextBasicFindTest.java
+++ b/src/test/java/hello/core/beanfind/ApplicationContextBasicFindTest.java
@@ -1,0 +1,49 @@
+package hello.core.beanfind;
+
+import hello.core.AppConfig;
+import hello.core.member.MemberService;
+import hello.core.member.MemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextBasicFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("빈 이름으로 조회")
+    void findBeanByName(){
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+//        System.out.println("memberService = " + memberService);
+//        System.out.println("memberService.getClass() = " + memberService.getClass());
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("이름 없이 타입으로만 조회")
+    void findBeanByType(){
+        MemberService memberService = ac.getBean(MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("구체 타입으로 조회")
+    void findBeanByName2(){
+        MemberServiceImpl memberService = ac.getBean("memberService", MemberServiceImpl.class);
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("빈 이름으로 조회 실패")
+    void findBeanNameX(){
+//        MemberService xxxxxx = ac.getBean("xxxxxx", MemberService.class);
+        // ac.getBean("xxxxxx", MemberService.class)를 실행하면 NoSuchBeanDefinitionException이 발생
+        assertThrows(NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("xxxxxx", MemberService.class));
+    }
+}

--- a/src/test/java/hello/core/beanfind/ApplicationContextExtendsFindTest.java
+++ b/src/test/java/hello/core/beanfind/ApplicationContextExtendsFindTest.java
@@ -1,0 +1,73 @@
+package hello.core.beanfind;
+
+import hello.core.discount.DiscountPolicy;
+import hello.core.discount.FixDiscountPolicy;
+import hello.core.discount.RateDiscountPolicy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextExtendsFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+    @Test
+    @DisplayName("부모 타입으로 조회 시 자식이 둘 이상 있으면 중복 오류가 발생")
+    void findBeanByParentTypeDuplicate(){
+        assertThrows(NoUniqueBeanDefinitionException.class,
+                () -> ac.getBean(DiscountPolicy.class));
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 조회 시 자식이 둘 이상 있으면, 타입을 지정하면 된다")
+    void findBeanByParentTypeBeanName(){
+        DiscountPolicy rateDiscountPolicy = ac.getBean("rateDiscountPolicy", DiscountPolicy.class);
+        assertThat(rateDiscountPolicy).isInstanceOf(DiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("특정 하위 타입으로 조회")
+    void findBeanBySubType() {
+        RateDiscountPolicy rateDiscountPolicy = ac.getBean(RateDiscountPolicy.class);
+        assertThat(rateDiscountPolicy).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 모두 조회하기")
+    void findBeanByParentType() {
+        Map<String, DiscountPolicy> beansOfType = ac.getBeansOfType(DiscountPolicy.class);
+        for (String key : beansOfType.keySet()){
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 모두 조회하기: Object")
+    void findAllBeanObjectType(){
+        Map<String, Object> beansOfType = ac.getBeansOfType(Object.class);
+        for (String key : beansOfType.keySet()){
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public DiscountPolicy rateDiscountPolicy() {
+            return new RateDiscountPolicy();
+        }
+
+        @Bean
+        public DiscountPolicy fixDiscountPolicy() {
+            return new FixDiscountPolicy();
+        }
+    }
+}

--- a/src/test/java/hello/core/beanfind/ApplicationContextInfoTest.java
+++ b/src/test/java/hello/core/beanfind/ApplicationContextInfoTest.java
@@ -1,0 +1,41 @@
+package hello.core.beanfind;
+
+import hello.core.AppConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class ApplicationContextInfoTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("모든 빈 출력하기")
+    void findAllBean(){
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+
+        for (String beanDefinitionName : beanDefinitionNames){
+            Object bean = ac.getBean(beanDefinitionName);
+            System.out.println("name = " + beanDefinitionName + " object = " + bean);
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 빈 출력하기")
+    void findApplicationBean(){
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames){
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            // Role ROLE_APPLICATION: 직접 등록한 애플리케이션 빈
+            // Role ROLE_INFRASTRUCTURE: 스프링이 내부에서 사용하는 빈
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION){
+                Object bean = ac.getBean(beanDefinitionName);
+                System.out.println("name = " + beanDefinitionName + " object = " + bean);
+            }
+        }
+    }
+
+
+}

--- a/src/test/java/hello/core/beanfind/ApplicationContextSameFindTest.java
+++ b/src/test/java/hello/core/beanfind/ApplicationContextSameFindTest.java
@@ -1,0 +1,60 @@
+package hello.core.beanfind;
+
+import hello.core.member.MemberRepository;
+import hello.core.member.MemoryMemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextSameFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SameBeanConfig.class);
+
+    @Test
+    @DisplayName("타입으로 조회 시 같은 타입이 둘 이상 있으면, 중복 오류가 발생한다")
+    void findBeanByTypeDuplicate(){
+        assertThrows(NoUniqueBeanDefinitionException.class,
+                () -> ac.getBean(MemberRepository.class));
+    }
+
+    @Test
+    @DisplayName("타입으로 조회 시 같은 타입이 둘 이상 있으면ㅡ 빈 이름을 지정하면 된다")
+    void findBeanByName(){
+        MemberRepository memberRepository = ac.getBean("memberRepository1", MemberRepository.class);
+        assertThat(memberRepository).isInstanceOf(MemberRepository.class);
+    }
+
+    @Test
+    @DisplayName("특정 타입을 모두 조회하기")
+    void findAllBeanByType() {
+        Map<String, MemberRepository> beansOfType = ac.getBeansOfType(MemberRepository.class);
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+        System.out.println("beansOfType = " + beansOfType);
+        assertThat(beansOfType.size()).isEqualTo(2);
+    }
+
+    // ApplicationContextSameFindTest 안에서만 쓰는 내부 클래스
+    @Configuration
+    static class SameBeanConfig {
+
+        @Bean
+        public MemberRepository memberRepository1() {
+            return new MemoryMemberRepository();
+        }
+
+        @Bean
+        public MemberRepository memberRepository2() {
+            return new MemoryMemberRepository();
+        }
+    }
+}


### PR DESCRIPTION
# ApplicationContext
-  자바 설정 클래스(AppConfig)를 기반으로 스프링 컨테이너 생성(ApplicationContext)
- ApplicationContext는 스프링 컨테이너이며 인터페이스이다
    - 스프링 컨테이너는 XML 기반으로 만들수도 있고 Annotation 기반의 자바 설정 클래스로 만들 수 있다.
    - AppConfig에 Configuration, Bean 애노테이션을 달아 애노테이션 기반의 자바 설정 클래스로 스프링 컨테이너를 만든다.
    - _XML 기반의 방식은 잘 사용하지 않는다._


## 컨테이너에 등록된 빈 조회
- **package: test.java.hello.core.beanfind**
- ApplicationContextInfoTest: 애플리케이션 빈 정보 출력
- ApplicationContextBasicFindTest: 스프링 빈 조회 기본
- ApplicationContextSameFindTest: 스프링 빈에 같은 타입의 인스턴스가 두개 이상 등록되었을 경우(중복) 조회
- ApplicationContextExtendsFindTest: 부모 타입으로 조회 시 자식이 둘 이상 있을 경우 조회