### PR TITLE
컴포넌트 스캔, 의존관계 자동 주입

### DIFF
--- a/src/main/java/hello/core/AppConfig.java
+++ b/src/main/java/hello/core/AppConfig.java
@@ -55,6 +55,7 @@ public class  AppConfig {
     public OrderService orderService(){
         System.out.println("call AppConfig.orderService");
         return new OrderServiceImpl(memberRepository(), discountPolicy());
+//        return new OrderServiceImpl();
     }
 
     @Bean

--- a/src/main/java/hello/core/AutoAppConfig.java
+++ b/src/main/java/hello/core/AutoAppConfig.java
@@ -1,0 +1,27 @@
+package hello.core;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+
+// 컴포넌트 스캔: @Component 애노테이션이 붙은 클래스를 스캔해서 스프링 빈으로 등록.
+// @Configuration 애노테이션도 @Component 애노테이션이 붙어있기 때문에 컴포넌트 스캔의 대상이 됨.
+// excludeFilters: 이전에 @Configuration 으로 등록된 TestConfig, AppConfig 가 컴포넌트 스캔의 대상이 되므로, 제외시켜줌.
+// MemoryMemberRepository, RateDiscountPolicy, MemberServiceImpl에 @Component 붙여준당
+// 컴포넌트 스캔 만으로는 의존관계 주입이 불가능하므로 @Autowired 라는 애노테이션을 사용(자동 의존관계 주입): ~ServiceImpl에서 사용
+@Configuration
+@ComponentScan(
+        basePackages = "hello.core.member", //basePackage: 탐색 위치 지정. member 패키지만 스캔.
+//        basePackageClasses : 지정한 클래스의 패키지를 탐색 시작 위치로 지정. 지정하지 않으면 @Configuration 이 붙은 클래스의 패키지가 시작위치.
+        excludeFilters =  @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
+)
+public class AutoAppConfig {
+
+    // 빈 이름 중복. 빈 이름 중복 시 자동 등록 빈 보다 수동 등록 빈이 우선적으로 등록됨.
+    // 수동 빈이 자동 빈을 오버라이딩해버린다. -> 현재는 스프링 부트가 오류를 내도록 수정됨.
+//    @Bean(name = "memoryMemberRepository")
+//    public MemberRepository memberRepository(){
+//        return new MemoryMemberRepository();
+//    }
+}

--- a/src/main/java/hello/core/AutoAppConfig.java
+++ b/src/main/java/hello/core/AutoAppConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.FilterType;
 // 컴포넌트 스캔 만으로는 의존관계 주입이 불가능하므로 @Autowired 라는 애노테이션을 사용(자동 의존관계 주입): ~ServiceImpl에서 사용
 @Configuration
 @ComponentScan(
-        basePackages = "hello.core.member", //basePackage: 탐색 위치 지정. member 패키지만 스캔.
+//        basePackages = "hello.core", //basePackage: 탐색 위치 지정. member 패키지만 스캔.
 //        basePackageClasses : 지정한 클래스의 패키지를 탐색 시작 위치로 지정. 지정하지 않으면 @Configuration 이 붙은 클래스의 패키지가 시작위치.
         excludeFilters =  @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
 )
@@ -20,8 +20,8 @@ public class AutoAppConfig {
 
     // 빈 이름 중복. 빈 이름 중복 시 자동 등록 빈 보다 수동 등록 빈이 우선적으로 등록됨.
     // 수동 빈이 자동 빈을 오버라이딩해버린다. -> 현재는 스프링 부트가 오류를 내도록 수정됨.
-//    @Bean(name = "memoryMemberRepository")
-//    public MemberRepository memberRepository(){
-//        return new MemoryMemberRepository();
-//    }
+/*    @Bean(name = "memoryMemberRepository")
+    public MemberRepository memberRepository(){
+        return new MemoryMemberRepository();
+    }*/
 }

--- a/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -2,7 +2,9 @@ package hello.core.discount;
 
 import hello.core.member.Grade;
 import hello.core.member.Member;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RateDiscountPolicy implements DiscountPolicy{
 
     private int discountPercent = 10;

--- a/src/main/java/hello/core/member/MemberServiceImpl.java
+++ b/src/main/java/hello/core/member/MemberServiceImpl.java
@@ -1,5 +1,9 @@
 package hello.core.member;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MemberServiceImpl implements MemberService {
 
     // MemberRepository는 인터페이스이며, 구현체를 필요로 함.
@@ -10,6 +14,7 @@ public class MemberServiceImpl implements MemberService {
     //-> 객체 생성부(new~)를 지우고 생성자를 만든다: memberRepository에 어떤 구현체가 들어갈 지는 객체 생성 시 결정
     private final MemberRepository memberRepository;
 
+    @Autowired
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/src/main/java/hello/core/member/MemoryMemberRepository.java
+++ b/src/main/java/hello/core/member/MemoryMemberRepository.java
@@ -1,8 +1,11 @@
 package hello.core.member;
 
-import java.util.Map;
-import java.util.HashMap;
+import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
 public class MemoryMemberRepository implements MemberRepository {
 
     // 실무에서는 동시성 이슈 때문에 ConcurrentHashMap 을 쓴다.

--- a/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -13,7 +13,29 @@ public class OrderServiceImpl implements OrderService{
 //    private final DiscountPolicy discountPolicy = new FixDiscountPolicy();
 //    private final DiscountPolicy discountPolicy = new RateDiscountPolicy();
 
-    // 객체 생성부(new~)를 없애고 생성자를 통해 주입받음
+/*    필드 주입 패턴
+    - 객체 생성부(new~)를 없애고 생성자를 통해 주입받음
+    - final: 값이 반드시 있어야 함을 의미. 생성자에 값을 채워넣어야 함
+    - 값을 변경할 수 없어 테스트가 어려움(테스트 시 더미로 memberRepository 등을 생성하여 넣을 수 없고, 값이 고정됨.)
+    - 필드 주입 패턴은 테스트코드에서 인스턴스를 새로 생성해서 사용할 때 많이 이용.
+    - OrderServiceTest, fieldInjectionTest 참고
+//    @Autowired private MemberRepository memberRepository;
+//    @Autowired private DiscountPolicy discountPolicy;
+ */
+    /*
+    일반 메서드 주입. 한 번에 여러 필드를 주입받을 수 있음. 일반적으로 잘 사용하지 않음
+    private MemberRepository memberRepository;
+    private DiscountPolicy discountPolicy;
+    @Autowired
+    public void init(MemberRepository memberRepository, DiscountPolicy discountPolicy){
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
+
+     */
+
+    //    생성자 주입 패턴
+    // 생성자가 딱 1개만 있으면 @Autowired 를 생략해도 의존관계 자동 주입
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 

--- a/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -3,7 +3,10 @@ package hello.core.order;
 import hello.core.discount.DiscountPolicy;
 import hello.core.member.Member;
 import hello.core.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class OrderServiceImpl implements OrderService{
 
 //    private final MemberRepository memberRepository = new MemoryMemberRepository();
@@ -14,6 +17,7 @@ public class OrderServiceImpl implements OrderService{
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/src/test/java/hello/core/autowired/AutowiredTest.java
+++ b/src/test/java/hello/core/autowired/AutowiredTest.java
@@ -1,0 +1,43 @@
+package hello.core.autowired;
+
+import hello.core.member.Member;
+import jakarta.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.Optional;
+
+public class AutowiredTest {
+
+    @Test
+    void autoWiredOption(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestBean.class);
+
+
+    }
+
+    static class TestBean{
+
+        // Member 클래스는 스프링 컨테이너에서 관리되는 빈이 아님
+        // @Autowired(required = false): 자동 주입할 대상이 없으면 수정자 메서드 자체가 호출 안 됨
+        // 따라서, setNoBean1은 호출 안됨
+        @Autowired(required = false)
+        public void setNoBean1(Member noBean1){
+            System.out.println("noBean1 = " + noBean1); // 미출력. 호출 X
+        }
+
+        // @Nullable: 자동 주입할 대상이 없으면 null 이 입력됨
+        @Autowired
+        public void setNobean2(@Nullable Member noBean2){
+            System.out.println("noBean2 = " + noBean2); // noBean2 = null
+        }
+
+        // 자동 주입할 대상이 없으면 Optional.empty 가 입력됨
+        @Autowired
+        public void setNoBean3(Optional<Member> noBean3){
+            System.out.println("noBean3 = " + noBean3); // noBean3 = Optional.empty
+        }
+    }
+}

--- a/src/test/java/hello/core/order/OrderServiceTest.java
+++ b/src/test/java/hello/core/order/OrderServiceTest.java
@@ -29,4 +29,17 @@ public class OrderServiceTest {
         Order order = orderService.createOrder(memberId, "itemA", 10000);
         Assertions.assertThat(order.getDiscountPrice()).isEqualTo(1000);
     }
+
+    /*
+    @Test
+    void fieldInjectionTest(){
+        OrderServiceImpl orderService = new OrderServiceImpl();
+//        orderService.createOrder(1L, "itemA", 10000);
+        // 자동 의존관계 주입: 필드 주입 방식 선택 시 NPE 터짐 -> setter 를 열어야 함 -> 수정자 주입 패턴으로 변경...
+        // 변경 가능성이 있음. 결국 요즘 잘 안씀...
+
+        orderService.setMemberRepository(new MemoryMemberRepository());
+        orderService.setDiscountPolicy(new FixDiscountPolicy());
+        orderService.createOrder(1L, "itemA", 10000);
+    }*/
 }

--- a/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,6 +1,8 @@
 package hello.core.scan;
 
+import hello.core.member.MemberRepository;
 import hello.core.member.MemberService;
+import hello.core.order.OrderServiceImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -14,5 +16,9 @@ public class AutoAppConfigTest {
 
         MemberService memberService = ac.getBean(MemberService.class);
         assertThat(memberService).isInstanceOf(MemberService.class);
+
+        OrderServiceImpl bean = ac.getBean(OrderServiceImpl.class);
+        MemberRepository memberRepository = bean.getMemberRepository();
+        System.out.println("memberRepository = " + memberRepository);
     }
 }

--- a/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,0 +1,18 @@
+package hello.core.scan;
+
+import hello.core.member.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AutoAppConfigTest {
+
+    @Test
+    void basicScan(){
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(hello.core.AutoAppConfig.class);
+
+        MemberService memberService = ac.getBean(MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}

--- a/src/test/java/hello/core/scan/filter/BeanA.java
+++ b/src/test/java/hello/core/scan/filter/BeanA.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyIncludeComponent
+public class BeanA {
+}

--- a/src/test/java/hello/core/scan/filter/BeanB.java
+++ b/src/test/java/hello/core/scan/filter/BeanB.java
@@ -1,0 +1,5 @@
+package hello.core.scan.filter;
+
+@MyExcludeComponent
+public class BeanB {
+}

--- a/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
+++ b/src/test/java/hello/core/scan/filter/ComponentFilterAppConfigTest.java
@@ -1,0 +1,38 @@
+package hello.core.scan.filter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ComponentFilterAppConfigTest {
+
+    @Test
+    void filterScan(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(ComponentFilterAppConfig.class);
+        BeanA beanA = ac.getBean("beanA", BeanA.class);
+        assertThat(beanA).isNotNull(); // null이 아니어야 함
+
+        //NoSuchBeanDefinitionException이 터져야 함.
+        Assertions.assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("beanB", BeanB.class)
+        );
+    }
+
+    @Configuration
+    @ComponentScan(
+            includeFilters = @Filter(type = FilterType.ANNOTATION, classes = MyIncludeComponent.class),
+            excludeFilters = @Filter(type = FilterType.ANNOTATION, classes = MyExcludeComponent.class)
+    )
+    static class ComponentFilterAppConfig{
+
+    }
+}

--- a/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
+++ b/src/test/java/hello/core/scan/filter/MyExcludeComponent.java
@@ -1,0 +1,10 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+
+}

--- a/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
+++ b/src/test/java/hello/core/scan/filter/MyIncludeComponent.java
@@ -1,0 +1,11 @@
+package hello.core.scan.filter;
+
+import java.lang.annotation.*;
+
+// @Component 에서 긁어옴
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+
+}


### PR DESCRIPTION
# Component Scan
- [AutoAppConfig](https://github.com/Chaewoonii/spring-basic/commit/c6c7c5eca58e7411222cec83998f2577629c1ae6#diff-533c880318d1c1956465ce897763b49cae2e9665571f296ffaba5a4cece3b536)
- 설정 정보 없이 자동으로 스프링 빈을 등록하는 기능. @Component 어노테이션이 붙은 클래스를 스캔하여 빈으로 등록
- Configuration 파일에 @Configuration, @ComponentScan 어노테이션을 붙여 사용한다
- @ComponentScan 어노테이션이 붙은 클래스의 패키지를 시작 위치로 지정한다.
    - basePackages 옵션을 통해 스캔 대상 패키지를 지정할 수 있다.
    - 컴포넌트 스캔은 @Component, @Controller, @Service, @Repository, @Configuration이 붙은 클래스를 스캔 대상에 포함한다.
- 필터: includeFilters, excludeFilters ([ComponentFilterAppConfigTest](https://github.com/Chaewoonii/spring-basic/commit/c6c7c5eca58e7411222cec83998f2577629c1ae6#diff-6aec4672ac3b6db90f71ac4e821f65df3cd45acf4f577a98a8e1ed804aa220d8))


# 의존관계 자동 주입
- 생성자 주입, 수정자 주입, 필드 주입, 일반 메서드 주입 4가지 방법이 있다.
- 생성자 주입 방식을 가장 많이 사용한다
- 의존관계 자동 주입 대상에 @Autowired 어노테이션을 붙여 사용

### 옵션처리
- 스프링 빈이 없어도 동작해야 할 경우, 자동 주입 대상을 옵션으로 처리한다
    - @Autowired(required=false): 자동 주입할 대상이 없으면 수정자 메서드 자체가 호출 안됨
    - @Nullable: 자동 주입할 대상이 없으면 null이 입력됨
    - Optional<>: 자동 주입할 대상이 없으면 Optional.empty가 입력됨
- [AutowiredTest](https://github.com/Chaewoonii/spring-basic/commit/8575185f6f37633b3d19b97b60f7e200cad38b39#diff-f5301bd200d13396a5be68f2e4cf044cead6515db2c214a5d46b3f31612d93a0)