### PR TITLE
모든 빈 조회, 빈 생명주기 콜백, 빈 스코프

### DIFF
--- a/src/test/java/hello/core/autowired/AllBeanTest.java
+++ b/src/test/java/hello/core/autowired/AllBeanTest.java
@@ -1,0 +1,57 @@
+package hello.core.autowired;
+
+import hello.core.AutoAppConfig;
+import hello.core.discount.DiscountPolicy;
+import hello.core.member.Grade;
+import hello.core.member.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 같은 타입으로 선언한 스프링 빈이 모두 필요할 때, Map이나 List로 받아올 수 있다.
+// RateDiscountPolicy, FixDiscountPolicy 둘 다 가져오기
+public class AllBeanTest {
+
+    @Test
+    void findAllBean(){
+        //                                                             AutoAppConfig 와 DiscountService에 있는 인스턴스를 빈으로 등록
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class, DiscountService.class);
+
+        DiscountService discountService = ac.getBean(DiscountService.class);
+        Member member = new Member(1L, "userA", Grade.VIP);
+
+        // 스프링 빈을 이름으로 가져와서 할인 정책 적용 (fix)
+        int fixDiscountPrice = discountService.discount(member, 10000, "fixDiscountPolicy");
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(fixDiscountPrice).isEqualTo(1000);
+
+        // 스프링 빈을 이름으로 가져와서 할인 정책 적용 (rate)
+        int rateDiscountPrice = discountService.discount(member, 20000, "rateDiscountPolicy");
+        assertThat(rateDiscountPrice).isEqualTo(2000);
+    }
+
+    static class DiscountService{
+        // map 의 키에 스프링빈의 이름을 넣어주고, 그 값으로 DiscountPolicy 타입으로 조회한 모든 스프링 빈을 담아준다.
+        private final Map<String, DiscountPolicy> policyMap;
+        private final List<DiscountPolicy> policies; // DiscountPolicy 타입으로 조회한 모든 스프링 빈을 담음.
+
+        @Autowired
+        public DiscountService(Map<String, DiscountPolicy> policyMap, List<DiscountPolicy> policies){
+            this.policyMap = policyMap;
+            this.policies = policies;
+            System.out.println("policyMap = " + policyMap);
+            System.out.println("policies = " + policies);
+        }
+
+        public int discount(Member member, int price, String discountCode) {
+            DiscountPolicy discountPolicy = policyMap.get(discountCode);// 들어오는 discountCode, 즉 빈 이름으로 스프링 빈을 가져옴
+            return discountPolicy.discount(member, price);
+        }
+    }
+}

--- a/src/test/java/hello/core/lifecycle/BeanLifecycleTest.java
+++ b/src/test/java/hello/core/lifecycle/BeanLifecycleTest.java
@@ -1,0 +1,32 @@
+package hello.core.lifecycle;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class BeanLifecycleTest {
+
+    @Test
+    public void lifeCycleTest(){
+        // ApplicationContext 는 NetworkClient.close() 사용 불가
+        // ConfigurableApplicationContext 는 AnnotationConfigApplicationContext 의 상위 인터페이스
+        ConfigurableApplicationContext ac = new AnnotationConfigApplicationContext(LifeCycleConfig.class);
+        NetworkClient client = ac.getBean(NetworkClient.class);
+        ac.close();
+    }
+
+    @Configuration
+    static class LifeCycleConfig{
+
+        // 초기화 및 종료 메서드 적용. 외부 라이브러리에도 적용 가능하다
+        // 스프링 빈의 종료 메서드(destroyMethod)는 inferred, "추론" 이다. close 나 shutdown 이라는 이름의 메서드를 자동으로 호출해준다.
+        @Bean //(initMethod = "init", destroyMethod = "close")
+        public NetworkClient networkClient(){
+            NetworkClient networkClient = new NetworkClient();
+            networkClient.setUrl("http://hello-spring.dev");
+            return networkClient;
+        }
+    }
+}

--- a/src/test/java/hello/core/lifecycle/NetworkClient.java
+++ b/src/test/java/hello/core/lifecycle/NetworkClient.java
@@ -1,0 +1,54 @@
+package hello.core.lifecycle;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+// InitializingBean, DisposableBean 상속 전에는 connect 가 null
+// 객체 생성 단계에서(생성자서) connect 와 call 이 이루어졌기 때문. (setUrl을 통하여 url이 초기화되기 전에 생성 단계에서 "연결 먼저" 수행됨)
+// afterPropertiesSet, destroy 를 통해 생성과 초기화를 분리: 객체 생성 후 초기화(setter 호출), 네트워크 연결
+// 요즘엔 잘 사용하지 않는다... : 코드를 고칠 수 없는 외부 라이브러리에 적용할 수 없음
+//public class NetworkClient implements InitializingBean, DisposableBean {
+public class NetworkClient {
+
+    private String url;
+
+    public NetworkClient() {
+        System.out.println("생성자 호출, url = " + url);
+//        connect();
+//        call("초기화 연결 메시지");
+    }
+
+    public void setUrl(String url){
+        this.url = url;
+    }
+
+    // 서비스 시작 시 호출
+    public void connect(){
+        System.out.println("connect: " + url);
+    }
+
+    public void call(String message){
+        System.out.println("call: " + url + " message = " + message);
+    }
+
+    // 서비스 종료시 호출
+    public void disconnect(){
+        System.out.println("close " + url);
+    }
+
+    // 의존관계 주입이 끝나면 호출
+    @PostConstruct // 최신 스프링 권장
+    public void init() throws Exception {
+        // 기존에 생성자에 포함되었던 객체 초기화 부분을 가져온다. 생성과 초기화는 분리하는 것이 유지보수 측면에서 좋음.
+        System.out.println("NetworkClient.init");
+        connect();
+        call("초기화 연결 메시지");
+    }
+
+    // 객체 소멸 시 호출
+    @PreDestroy // 최신 스프링 권장
+    public void close() throws Exception {
+        System.out.println("NetworkClient.close");
+        disconnect();
+    }
+}

--- a/src/test/java/hello/core/scope/PrototypeTest.java
+++ b/src/test/java/hello/core/scope/PrototypeTest.java
@@ -1,0 +1,44 @@
+package hello.core.scope;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Scope;
+
+public class PrototypeTest {
+
+    @Test
+    void prototypeBeanFind(){
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(PrototypeBean.class);
+
+        System.out.println("find prototypeBean1");
+        PrototypeBean prototypeBean1 = ac.getBean(PrototypeBean.class);
+        System.out.println("find prototypeBean2");
+        PrototypeBean prototypeBean2 = ac.getBean(PrototypeBean.class);
+        System.out.println("prototypeBean1 = " + prototypeBean1);
+        System.out.println("prototypeBean2 = " + prototypeBean2);
+        Assertions.assertThat(prototypeBean1).isNotSameAs(prototypeBean2);
+
+//        prototypeBean1.destroy(); // 클라이언트가 직접 종료
+//        prototypeBean2.destroy();
+        ac.close();
+    }
+
+    @Scope("prototype")
+//    @Component 생략 가능: AnnotationConfigApplicationContext 에 PrototypeBean 클래스를 넣었으므로
+//    클래스 자체가 컴포넌트 스캔의 대상처럼 동작함: 바로 스프링 빈으로 등록
+    static class PrototypeBean{
+
+        @PostConstruct
+        void init(){
+            System.out.println("PrototypeBean.init");
+        }
+
+        @PreDestroy
+        void destroy(){
+            System.out.println("PrototypeBean.destroy");
+        }
+    }
+}

--- a/src/test/java/hello/core/scope/SingletonTest.java
+++ b/src/test/java/hello/core/scope/SingletonTest.java
@@ -1,0 +1,38 @@
+package hello.core.scope;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonTest {
+
+    @Test
+    void singletonBeanFind(){
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SingletonBean.class);
+
+        SingletonBean singletonBean1 = ac.getBean(SingletonBean.class);
+        SingletonBean singletonBean2 = ac.getBean(SingletonBean.class);
+        System.out.println("singletonBean1 = " + singletonBean1);
+        System.out.println("singletonBean2 = " + singletonBean2);
+        assertThat(singletonBean1).isSameAs(singletonBean2);
+
+        ac.close();
+    }
+
+    @Scope("singleton")
+    static class SingletonBean{
+        @PostConstruct
+        public void init(){
+            System.out.println("SingletonBean.init");
+        }
+
+        @PreDestroy
+        public void destroy(){
+            System.out.println("SingletonBean.destroy");
+        }
+    }
+}

--- a/src/test/java/hello/core/scope/SingletonWithPrototypeTest1.java
+++ b/src/test/java/hello/core/scope/SingletonWithPrototypeTest1.java
@@ -1,0 +1,47 @@
+package hello.core.scope;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonWithPrototypeTest1 {
+
+    @Test
+    void prototypeFind(){
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(PrototypeBean.class);
+        PrototypeBean prototypeBean1 = ac.getBean(PrototypeBean.class);
+        prototypeBean1.addCount();
+        assertThat(prototypeBean1.getCount()).isEqualTo(1);
+
+        PrototypeBean prototypeBean2 = ac.getBean(PrototypeBean.class);
+        prototypeBean2.addCount();
+        assertThat(prototypeBean2.getCount()).isEqualTo(1);
+    }
+
+    @Scope("prototype")
+    static class PrototypeBean{
+        private int count = 0;
+
+        public void addCount(){
+            count++;
+        }
+
+        public int getCount(){
+            return count;
+        }
+
+        @PostConstruct
+        public void init(){
+            System.out.println("PrototypeBean.init " + this);
+        }
+
+        @PreDestroy
+        public void destroy(){
+            System.out.println("PrototypeBean.destroy");
+        }
+    }
+}


### PR DESCRIPTION
## 모든 빈 조회
- **package: test.hello.core.autowired**
- [AllBeanTest](https://github.com/Chaewoonii/spring-basic/commit/da066d6bc26fd4d5f739637f2b7a80d94527ad44#diff-bc4121850b7e2cf249d8c3e5740fefab84167fd589eb146e8e54432c83013748):  모든 빈 조회(Map, List로 가져오기)

## 빈 생명주기 콜백
- **package: test.hello.core.lifecycle**
- [BeanLifecycleTest](https://github.com/Chaewoonii/spring-basic/commit/0de30caade4cb3d8be02f46f7bb815f4501fe3b9#diff-b744454a31bedbfa3c7687ac5eef5535208c56036ebff330fd75ca5123ee8603): 빈 생명주기 콜백 테스트
- [NetworkClient](https://github.com/Chaewoonii/spring-basic/commit/0de30caade4cb3d8be02f46f7bb815f4501fe3b9#diff-3aa993cdb8f7bc8afe2f1f046d92fa8be0eab6bc128b12954130c2bfee66fd12): 네트워크 클라이언트 클래스. 빈 생명주기 콜백 테스트용
    - init: 객체 생성 후 의존관계 주입이 끝나면 호출 (PostConstruct 어노테이션)
    - close: 객체 소멸 전 호출 (PreDestroy 어노테이션)
    - 객체의 생성과 초기화는 분리하는 것이 유지보수 측면에서 좋다. 
    - PostConstruct, PreDestroy  는 스프링에 종속적인 기술이 아니라 자바 표준이다. 따라서 스프링이 아닌 다른 컨테이너에서도 동작한다

## 빈 스코프
- **package: test.hello.core.scope**
- **싱글톤**: 기본 스코프, 스프링 컨테이너의 시작과 종료까지 유지되는 가장 넓은 범위의 스코프
- **프로토타입**:스프링 컨테이너는 프로토타입 빈의 생성과 의존관계 주입까지만 관여하고 더는 관리하지 않는 매우 짧은 범위의 스코프
- [PrototypeTest](https://github.com/Chaewoonii/spring-basic/commit/0de30caade4cb3d8be02f46f7bb815f4501fe3b9#diff-19fb32b9cdb6fea846a6fd1c1b7f70b60dbd6d08932839aeac22409252b09709): 빈 스코프 - 프로토타입 테스트. 
- [SingletonTest](https://github.com/Chaewoonii/spring-basic/commit/0de30caade4cb3d8be02f46f7bb815f4501fe3b9#diff-8cf09ed399b1fd397c8cf85409dd7fa701d868f58c1580c7bf49f1200c8ca46d): 빈 스코프 - 싱글톤 테스트
- [SingletonWithPrototypeTest1](https://github.com/Chaewoonii/spring-basic/commit/0de30caade4cb3d8be02f46f7bb815f4501fe3b9#diff-ac832cc3341b483442bfa01edb56a4d96095ee750a84af73fbc10c6482ba568f): 싱글톤과 프로토타입을 함께 사용할 경우의 문제점(ing)
