### PR TITLE
빈 스코프: 웹 스코프

### DIFF
--- a/src/main/java/hello/core/common/MyLogger.java
+++ b/src/main/java/hello/core/common/MyLogger.java
@@ -1,0 +1,35 @@
+package hello.core.common;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class MyLogger {
+
+    private String uuid;
+    private String requestURL;
+
+    public void setRequestURL(String requestURL){
+        this.requestURL = requestURL;
+    }
+
+    public void log(String message){
+        System.out.println("[" + uuid + "]" + "[" + requestURL + "]" + message);
+    }
+
+    @PostConstruct
+    public void init(){
+        uuid = UUID.randomUUID().toString();
+        System.out.println("[" + uuid + "] request scope bean create: " + this);
+    }
+
+    @PreDestroy
+    public void close(){System.out.println("[" + uuid + "] request scope bean close: " + this);
+    }
+}

--- a/src/main/java/hello/core/web/LogDemoController.java
+++ b/src/main/java/hello/core/web/LogDemoController.java
@@ -1,0 +1,47 @@
+package hello.core.web;
+
+import hello.core.common.MyLogger;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequiredArgsConstructor
+public class LogDemoController {
+
+    private final LonDemoService logDemoService;
+    private final MyLogger myLogger; // DL: Dependency Lookup
+
+    /*
+    * 오류 발생: Scope 'request' is not active~
+    * MyLogger 의 스코프는 http 요청이 들어오고 나갈 때 까지이다.
+    * 그런데, 스프링이 올라갈 때 의존관계 주입을 위해 MyLogger가 필요하다
+    * http 요청이 들어오지도 않았는데 (빈이 생성되지도 않았는데), MyLogger를 요청하니 오류가 발생한다.
+    * ----> Provider 로 해결!!
+    *       -> @Scope 에서 proxyMode = ScopedProxyMode.TARGET_CLASS 를 활용하여 코드라인 줄임
+    *       -> 클래스면 TARGET_CLASS, 인터페이스면 INTERFACES 를 선택
+    *       -> MyLogger 의 가짜 프록시 클래스를 만들어두고 Http request와 상관 없이 가짜 프록시 클래스를 다른 빈에 미리 주입해둘 수 있다.
+    * ----> 스프링 인터셉터나 서블릿 필터를 활용해도 좋다
+    * */
+
+    @SneakyThrows
+    @RequestMapping("log-demo")
+    @ResponseBody
+    public String logDemo(HttpServletRequest request){
+        String requestURL = request.getRequestURL().toString();
+//        MyLogger myLogger = myLoggerProvider.getObject();
+        System.out.println("myLogger = " + myLogger.getClass()); // SpringCGLIB: 가짜 프록시 클래스
+        myLogger.setRequestURL(requestURL); // myLogger 의 기능을 사용해야할 때 진짜 MyLogger 클래스를 찾아서 동작. 마치 provider 처럼 동작한다.
+
+        myLogger.log("controller test");
+        Thread.sleep(1000);
+        logDemoService.logic("testId");
+        return "OK";
+    }
+
+
+
+}

--- a/src/main/java/hello/core/web/LonDemoService.java
+++ b/src/main/java/hello/core/web/LonDemoService.java
@@ -1,0 +1,17 @@
+package hello.core.web;
+
+import hello.core.common.MyLogger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LonDemoService {
+
+    private final MyLogger myLogger;
+
+    public void logic(String id) {
+//        MyLogger myLogger = myLoggerProvider.getObject();
+        myLogger.log("service id = " + id);
+    }
+}

--- a/src/test/java/hello/core/scope/SingletonWithPrototypeTest1.java
+++ b/src/test/java/hello/core/scope/SingletonWithPrototypeTest1.java
@@ -2,7 +2,9 @@ package hello.core.scope;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import jakarta.inject.Provider;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Scope;
 
@@ -20,6 +22,36 @@ public class SingletonWithPrototypeTest1 {
         PrototypeBean prototypeBean2 = ac.getBean(PrototypeBean.class);
         prototypeBean2.addCount();
         assertThat(prototypeBean2.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    void singletonClientUsePrototype(){
+        AnnotationConfigApplicationContext ac =
+                new AnnotationConfigApplicationContext(ClientBean.class, PrototypeBean.class);
+
+        ClientBean clientBean1 = ac.getBean(ClientBean.class);
+        int count1 = clientBean1.logic();
+        assertThat(count1).isEqualTo(1);
+
+        ClientBean clientBean2 = ac.getBean(ClientBean.class);
+        int count2 = clientBean2.logic();
+        assertThat(count2).isEqualTo(1);
+    }
+
+    @Scope("singleton")
+    static class ClientBean{
+//        private final PrototypeBean prototypeBean; // 생성시점에 주입
+
+        @Autowired
+//        private ObjectProvider<PrototypeBean> prototypeBeanObjectProvider;
+        private Provider<PrototypeBean> prototypeBeanObjectProvider;
+
+        public int logic(){
+//            PrototypeBean prototypeBean = prototypeBeanObjectProvider.getObject(); // ObjectProvider 를 사용할 경우
+            PrototypeBean prototypeBean = prototypeBeanObjectProvider.get(); // Provider 를 사용할 경우
+            prototypeBean.addCount();
+            return prototypeBean.getCount();
+        }
     }
 
     @Scope("prototype")


### PR DESCRIPTION
## 웹 스코프
- 웹 스코프: 웹 환경에서만 동작. 프로토타입과 다르기 스프링이 해당 스코프의 종료 시점까지만 관리.
    - **request**: HTTP 요청 하나가 들어오고 나갈 때 까지 유지되는 스코프, 각각의 HTTP 요청마다 별도의 빈 인스턴스가 생성 및 관리됨.
    - **session**: Http Session과 동일한 생명주기를 가짐
    - **application**: 서블릿 컨텍스트(`ServletContext`)와 동일한 생명주기를 가지는 스코프
    - **websocket**: 웹 소켓과 동일한 생명주기를 가짐
- **build.gradle**에 Spring boot starter web 라이브러리 추가.
- **request 스코프 예제**
    - [MyLogger](https://github.com/Chaewoonii/spring-basic/compare/studing?expand=1#diff-5563fd1f2adf07d80468b1212dfbc42f660c003a63a87a5df9231d37523bc5fe): 로그 출력 클래스. `@Scope(value="request")` 사용, request 스코프로 지정. 생성 시점에 `@PostConstruct` 초기화 메서드 사용, UUID 생성 및 저장. 종료 시점에는 `@PreDestroy` 활용, 종료 메시지 출력
    - [LogDemoController](https://github.com/Chaewoonii/spring-basic/compare/studing?expand=1#diff-7a282e78e2d7079c1076d1ecf7e10e5e959d4fabdd162a57baa6c8da3049661e): 로거가 동작하는지 확인하는 테스트용 컨트롤러
    - [LonDemoService.](https://github.com/Chaewoonii/spring-basic/compare/studing?expand=1#diff-9345452002542edc14b34f05c7ebed1be1de9eb543d58a680d486342de32038d): 서비스 계층.
- 빈 주입 오류 발생: 빈 생성 지연 전략 사용
    - **Provider**: `ObjectProvider.getObject` 활용
    - **프록시**: `@Scope(value="request", proxyMode = ScopeProxyMode.TARGET_CLASS)` 프록시 모드 사용
        - 적용 대상이 인터페이스가 아닌 클래스일 경우 `TARGET_CLASS` 를 선택
        - 적용 대상이 인터페이스일 경우 `INTERFACES` 선택
        - 스프링에서 CGLIB 라는 라이브러리로 적용 대상 클래스를 상속받은 **가짜 프록시 객체**를 만들어 주입. 가짜 프록시 객체는 **요청이 오면 그 때 내부에서 진짜 빈을 요청하는 위임 로직**을 갖고있다.
